### PR TITLE
Add header and footer styling

### DIFF
--- a/helene-clean/helene-landing.css
+++ b/helene-clean/helene-landing.css
@@ -390,3 +390,63 @@ body {
     text-align: center;
   }
 }
+
+/* === Helene Landing Header and Footer Styling === */
+header.site-header {
+  background-color: #ffffff;
+  padding: 1.5rem 2rem;
+  border-bottom: 2px solid #eee;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  font-family: 'Montserrat', sans-serif;
+}
+
+.site-title a {
+  color: #9d509f;
+  font-weight: 600;
+  font-size: 1.5rem;
+  text-decoration: none;
+}
+
+.site-title a:hover {
+  color: #e03694;
+}
+
+.site-description {
+  color: #666;
+  font-size: 0.95rem;
+  margin-top: 0.25rem;
+}
+
+#site-navigation .main-navigation ul li a {
+  color: #333;
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  transition: color 0.3s ease;
+}
+
+#site-navigation .main-navigation ul li a:hover {
+  color: #9d509f;
+}
+
+.menu-toggle {
+  background-color: transparent;
+  border: none;
+  color: #9d509f;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+footer.brand-footer {
+  background-color: #f8f8f8;
+  padding: 2rem;
+  text-align: center;
+  border-top: 2px solid #eee;
+  font-family: 'Montserrat', sans-serif;
+  color: #555;
+}
+
+footer.brand-footer img {
+  max-height: 60px;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- style WordPress header, navigation menu, and footer
- match Helene landing design

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c792b638483309a195812ed832f0e