### PR TITLE
Improve header responsiveness

### DIFF
--- a/helene-clean/functions.php
+++ b/helene-clean/functions.php
@@ -155,7 +155,8 @@ function helene_clean_scripts() {
         }
 	wp_style_add_data( 'helene-clean-style', 'rtl', 'replace' );
 
-	wp_enqueue_script( 'helene-clean-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
+        wp_enqueue_script( 'helene-clean-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
+        wp_enqueue_script( 'helene-nav-toggle', get_template_directory_uri() . '/js/nav-toggle.js', array(), _S_VERSION, true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/helene-clean/header.php
+++ b/helene-clean/header.php
@@ -45,8 +45,11 @@
 			<?php endif; ?>
 		</div><!-- .site-branding -->
 
-		<nav id="site-navigation" class="main-navigation">
-			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'helene-clean' ); ?></button>
+                <nav id="site-navigation" class="main-navigation">
+                        <button id="nav-toggle" class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">
+                                <span class="hamburger" aria-hidden="true"></span>
+                                <span class="screen-reader-text"><?php esc_html_e( 'Primary Menu', 'helene-clean' ); ?></span>
+                        </button>
 			<?php
 			wp_nav_menu(
 				array(

--- a/helene-clean/helene-landing.css
+++ b/helene-clean/helene-landing.css
@@ -393,11 +393,19 @@ body {
 
 /* === Helene Landing Header and Footer Styling === */
 header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
   background-color: #ffffff;
   padding: 1.5rem 2rem;
   border-bottom: 2px solid #eee;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
   font-family: 'Montserrat', sans-serif;
+  transition: box-shadow 0.3s ease;
+}
+
+header.site-header.scrolled {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 .site-title a {
@@ -425,7 +433,8 @@ header.site-header {
   transition: color 0.3s ease;
 }
 
-#site-navigation .main-navigation ul li a:hover {
+#site-navigation .main-navigation ul li a:hover,
+#site-navigation .main-navigation ul li a:focus {
   color: #9d509f;
 }
 
@@ -435,6 +444,92 @@ header.site-header {
   color: #9d509f;
   font-size: 1rem;
   cursor: pointer;
+  position: relative;
+  width: 30px;
+  height: 24px;
+  display: none;
+  padding: 0;
+}
+
+.menu-toggle .hamburger,
+.menu-toggle .hamburger::before,
+.menu-toggle .hamburger::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 3px;
+  background: #333;
+  position: absolute;
+  left: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.menu-toggle .hamburger {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.menu-toggle .hamburger::before {
+  top: -8px;
+}
+
+.menu-toggle .hamburger::after {
+  top: 8px;
+}
+
+.menu-toggle.open .hamburger {
+  background: transparent;
+}
+
+.menu-toggle.open .hamburger::before {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.menu-toggle.open .hamburger::after {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+/* Navigation layout */
+.main-navigation ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.main-navigation li {
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .menu-toggle {
+    display: block;
+  }
+
+  #site-navigation {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+  }
+
+  #site-navigation.toggled {
+    max-height: 300px;
+  }
+
+  .main-navigation ul {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .main-navigation li {
+    width: 100%;
+  }
 }
 
 footer.brand-footer {

--- a/helene-clean/js/nav-toggle.js
+++ b/helene-clean/js/nav-toggle.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const header=document.getElementById('masthead');
+  const toggle=document.getElementById('nav-toggle');
+  if(toggle){
+    toggle.addEventListener('click',()=>{
+      toggle.classList.toggle('open');
+    });
+  }
+  if(header){
+    window.addEventListener('scroll',()=>{
+      if(window.scrollY>0){
+        header.classList.add('scrolled');
+      }else{
+        header.classList.remove('scrolled');
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- make the header sticky with scroll shadow
- add animated hamburger markup in header
- support mobile menu and sticky behavior in CSS
- enqueue new nav-toggle script for menu/hamburger behavior

## Testing
- `npm --prefix helene-clean run lint:js` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c863136108330b9d411f2737fbe12