### PR TITLE
Improve header responsiveness

### DIFF
--- a/helene-clean/functions.php
+++ b/helene-clean/functions.php
@@ -155,7 +155,8 @@ function helene_clean_scripts() {
         }
 	wp_style_add_data( 'helene-clean-style', 'rtl', 'replace' );
 
-	wp_enqueue_script( 'helene-clean-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
+        wp_enqueue_script( 'helene-clean-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
+        wp_enqueue_script( 'helene-nav-toggle', get_template_directory_uri() . '/js/nav-toggle.js', array(), _S_VERSION, true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/helene-clean/header.php
+++ b/helene-clean/header.php
@@ -27,17 +27,17 @@
 
 	<header id="masthead" class="site-header">
 		<div class="site-branding">
-			<?php
-			the_custom_logo();
-			if ( is_front_page() && is_home() ) :
-				?>
-				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-				<?php
-			else :
-				?>
-				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-				<?php
-			endif;
+                       <?php
+                       $logo_markup = '<a href="' . esc_url( home_url( '/' ) ) . '" rel="home"><img src="' . esc_url( get_template_directory_uri() . '/imgs/SparkPointLogoMain.png' ) . '" class="site-logo" alt="' . esc_attr( get_bloginfo( 'name' ) ) . '" /></a>';
+                       if ( is_front_page() && is_home() ) :
+                               ?>
+                               <h1 class="site-title"><?php echo $logo_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
+                               <?php
+                       else :
+                               ?>
+                               <p class="site-title"><?php echo $logo_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+                               <?php
+                       endif;
 			$helene_clean_description = get_bloginfo( 'description', 'display' );
 			if ( $helene_clean_description || is_customize_preview() ) :
 				?>
@@ -45,8 +45,11 @@
 			<?php endif; ?>
 		</div><!-- .site-branding -->
 
-		<nav id="site-navigation" class="main-navigation">
-			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'helene-clean' ); ?></button>
+               <nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Primary Menu', 'helene-clean' ); ?>">
+                        <button id="nav-toggle" class="menu-toggle" aria-controls="primary-menu" aria-expanded="false" aria-label="<?php esc_attr_e( 'Toggle navigation', 'helene-clean' ); ?>">
+                                <span class="hamburger" aria-hidden="true"></span>
+                                <span class="screen-reader-text"><?php esc_html_e( 'Primary Menu', 'helene-clean' ); ?></span>
+                        </button>
 			<?php
 			wp_nav_menu(
 				array(

--- a/helene-clean/helene-landing.css
+++ b/helene-clean/helene-landing.css
@@ -393,22 +393,40 @@ body {
 
 /* === Helene Landing Header and Footer Styling === */
 header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
   background-color: #ffffff;
   padding: 1.5rem 2rem;
   border-bottom: 2px solid #eee;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
   font-family: 'Montserrat', sans-serif;
+  transition: box-shadow 0.3s ease;
+}
+
+.site-branding {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.site-logo {
+  max-height: 50px;
+}
+
+header.site-header.scrolled {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 .site-title a {
-  color: #9d509f;
-  font-weight: 600;
-  font-size: 1.5rem;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
 }
 
-.site-title a:hover {
-  color: #e03694;
+.site-title img {
+  max-height: 50px;
 }
 
 .site-description {
@@ -423,10 +441,29 @@ header.site-header {
   text-transform: uppercase;
   font-size: 0.9rem;
   transition: color 0.3s ease;
+  position: relative;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
-#site-navigation .main-navigation ul li a:hover {
+#site-navigation .main-navigation ul li a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 2px;
+  background: #9d509f;
+  transition: width 0.3s ease;
+}
+
+#site-navigation .main-navigation ul li a:hover,
+#site-navigation .main-navigation ul li a:focus {
   color: #9d509f;
+}
+
+#site-navigation .main-navigation ul li a:hover::after,
+#site-navigation .main-navigation ul li a:focus::after {
+  width: 100%;
 }
 
 .menu-toggle {
@@ -435,6 +472,92 @@ header.site-header {
   color: #9d509f;
   font-size: 1rem;
   cursor: pointer;
+  position: relative;
+  width: 30px;
+  height: 24px;
+  display: none;
+  padding: 0;
+}
+
+.menu-toggle .hamburger,
+.menu-toggle .hamburger::before,
+.menu-toggle .hamburger::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 3px;
+  background: #333;
+  position: absolute;
+  left: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.menu-toggle .hamburger {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.menu-toggle .hamburger::before {
+  top: -8px;
+}
+
+.menu-toggle .hamburger::after {
+  top: 8px;
+}
+
+.menu-toggle.open .hamburger {
+  background: transparent;
+}
+
+.menu-toggle.open .hamburger::before {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.menu-toggle.open .hamburger::after {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+/* Navigation layout */
+.main-navigation ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.main-navigation li {
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .menu-toggle {
+    display: block;
+  }
+
+  #site-navigation {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+  }
+
+  #site-navigation.toggled {
+    max-height: 300px;
+  }
+
+  .main-navigation ul {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .main-navigation li {
+    width: 100%;
+  }
 }
 
 footer.brand-footer {

--- a/helene-clean/js/nav-toggle.js
+++ b/helene-clean/js/nav-toggle.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const header = document.getElementById('masthead');
+  const toggle = document.getElementById('nav-toggle');
+  const nav = document.getElementById('site-navigation');
+
+  if (toggle && nav) {
+    toggle.addEventListener('click', function () {
+      toggle.classList.toggle('open');
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!nav.contains(e.target) && e.target !== toggle) {
+        toggle.classList.remove('open');
+      }
+    });
+  }
+
+  if (header) {
+    window.addEventListener('scroll', function () {
+      if (window.scrollY > 0) {
+        header.classList.add('scrolled');
+      } else {
+        header.classList.remove('scrolled');
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- make header sticky with scroll shadow
- swap site title text for SparkPoint logo
- add hover underline effect and font tweaks
- style brand block and navigation for responsiveness
- ensure toggle icon resets when menu closes

## Testing
- `npm --prefix helene-clean run lint:js` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c863136108330b9d411f2737fbe12