### PR TITLE
Remove redundant custom logo support

### DIFF
--- a/helene-clean/functions.php
+++ b/helene-clean/functions.php
@@ -90,7 +90,6 @@ function helene_clean_setup() {
 	 *
 	 * @link https://codex.wordpress.org/Theme_Logo
 	 */
-       add_theme_support( 'custom-logo' );
        add_theme_support(
                'custom-logo',
                array(


### PR DESCRIPTION
## Summary
- remove the first `add_theme_support('custom-logo')` call so the second call with parameters handles it

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686c9ab322688330815422eb35482413