### PR TITLE
Fix missing head markup for theme CSS

### DIFF
--- a/helene-clean/header.php
+++ b/helene-clean/header.php
@@ -1,3 +1,14 @@
+<!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="profile" href="https://gmpg.org/xfn/11">
+    <?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <header id="masthead" class="site-header">
 	<div class="site-branding">
 		<?php


### PR DESCRIPTION
## Summary
- include `<head>` and WordPress hooks in theme header

## Testing
- `php -l helene-clean/header.php`
- `npm run compile:css` *(fails: node-sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d09c07483309a8e3c0b3acdd9e0